### PR TITLE
Refactor, cleanup and improve python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /media/
 /__pycache__/
+pip.log
+todo.md

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,14 +1,14 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Python: Current File",
-            "type": "python",
+            "name": "Manim: Current File (module)",
+            "type": "debugpy",
             "request": "launch",
-            "program": "manim.py ${file}",
+            "module": "manim",
+            "args": [
+                "${file}"
+            ],
             "console": "integratedTerminal"
         }
     ]

--- a/fourierseries.py
+++ b/fourierseries.py
@@ -126,7 +126,7 @@ class FourierSceneAbstract(mn.ZoomedScene):
             real_fss = np.array([np.real(fss), np.imag(fss), 0])
             return real_fss
         
-        t_range = np.array([0, 1, self.parametric_func_step])
+        t_range = (0, 1, self.parametric_func_step)
         vector_sum_path = mn.ParametricFunction(fourier_series_func, t_range = t_range)
         broken_path = mn.CurvesAsSubmobjects(vector_sum_path)
         broken_path.stroke_width = 0

--- a/fourierseries.py
+++ b/fourierseries.py
@@ -46,13 +46,15 @@ class FourierSceneAbstract(ZoomedScene):
         self.slow_factor_tracker = ValueTracker(0)
         self.add(self.vector_clock)
 
-    def start_vector_clock(self):           # This updates vector_clock to follow the add_updater parameter dt
-        self.vector_clock.add_updater(
-            lambda t, dt: t.increment_value(dt * self.slow_factor_tracker.get_value() / self.cycle_seconds)
-        )
+    def vector_clock_time_updater(self, t, dt):
+        scaled_dt = dt * self.slow_factor_tracker.get_value() / self.cycle_seconds
+        t.increment_value(scaled_dt)
+
+    def start_vector_clock(self):           
+        self.vector_clock.add_updater(self.vector_clock_time_updater)
 
     def stop_vector_clock(self):
-        self.vector_clock.remove_updater(self.start_vector_clock)
+        self.vector_clock.remove_updater(self.vector_clock_time_updater)
 
     def get_fourier_coefs(self, path):
         dt = 1 / self.path_n_samples

--- a/fourierseries.py
+++ b/fourierseries.py
@@ -3,7 +3,7 @@
 # Theorem of Beethoven link:    https://www.youtube.com/watch?v=2tTshwWTEic
 # Adapted from CairoManim to ManimCE
 # Inspired by brilliant math youtuber 3Blue1Brown, creator of the Manim Python library:
-# 3lue1Brown link:              https://www.youtube.com/watch?v=r6sGWTCMz2k
+# 3Blue1Brown link:              https://www.youtube.com/watch?v=r6sGWTCMz2k
 
 from __future__ import annotations
 
@@ -66,7 +66,7 @@ class FourierSceneAbstract(mn.ZoomedScene):
     def stop_vector_clock(self) -> None:
         self.vector_clock.remove_updater(self.vector_clock_time_updater)
 
-    def get_fourier_coefs(self, path: "mn.VMobject") -> list[complex]:
+    def get_fourier_coefficients(self, path: "mn.VMobject") -> list[complex]:
         """Compute Fourier coefficients for the given `path`.
 
         Samples the path at `self.path_n_samples` points and produces complex
@@ -96,7 +96,7 @@ class FourierSceneAbstract(mn.ZoomedScene):
         Each produced vector has attributes `.freq`, `.coef`, `.phase`, and
         `.center_func` so that other helpers can position and animate them.
         """
-        coefficients = self.get_fourier_coefs(path)
+        coefficients = self.get_fourier_coefficients(path)
 
         vectors = mn.VGroup()
         v_is_first_vector = True
@@ -125,7 +125,7 @@ class FourierSceneAbstract(mn.ZoomedScene):
         for v in vectors:
             time = self.vector_clock.get_value()
             v.shift(v.center_func()-v.get_start())
-            v.set_angle(v.phase + time * v.freq * mn.TAU)  # NOTE Rotate() did not work here for unknown reason, probably related to how manin handles updaters
+            v.set_angle(v.phase + time * v.freq * mn.TAU)  # NOTE Rotate() did not work here for unknown reason, probably related to how manim handles updaters
               
     def get_circles(self, vectors: "mn.VGroup") -> "mn.VGroup":
         """Create circles centered on each vector start."""
@@ -185,7 +185,7 @@ class FourierScene(FourierSceneAbstract):
     def get_tex_symbol(self, symbol: str, color: "mn.ManimColor" = None) -> "mn.Tex":
         symbol = mn.Tex(symbol, **self.fourier_symbol_config)
     
-        if (color is not None):
+        if color is not None:
             symbol.set_color(color)
 
         return symbol

--- a/fourierseries.py
+++ b/fourierseries.py
@@ -5,14 +5,24 @@
 # Inspired by brilliant math youtuber 3Blue1Brown, creator of the Manim Python library:
 # 3lue1Brown link:              https://www.youtube.com/watch?v=r6sGWTCMz2k
 
+from __future__ import annotations
+
 import manim as mn
 import numpy as np
+from typing import  Iterable 
 # import timeit
 
 # config.use_opengl_renderer = True
 
 class FourierSceneAbstract(mn.ZoomedScene):
-    def __init__(self):
+    """Base scene for Fourier visualizations.
+
+    Provides helpers to compute Fourier coefficients from a path, create the
+    rotating vectors and their companion circles, and build the drawn path
+    produced by the vector sum.
+    """
+
+    def __init__(self) -> None:
         super().__init__()
         self.fourier_symbol_config = {
             "stroke_width": 1,
@@ -40,23 +50,28 @@ class FourierSceneAbstract(mn.ZoomedScene):
         self.freqs = list(range(-self.n_vectors // 2, self.n_vectors // 2 + 1, 1))
         self.freqs.sort(key=abs)
 
-    def setup(self):
+    def setup(self) -> None:
         super().setup()
         self.vector_clock = mn.ValueTracker()
         self.slow_factor_tracker = mn.ValueTracker(0)
         self.add(self.vector_clock)
 
-    def vector_clock_time_updater(self, t, dt):
+    def vector_clock_time_updater(self, t: "mn.ValueTracker", dt: float) -> None:
         scaled_dt = dt * self.slow_factor_tracker.get_value() / self.cycle_seconds
         t.increment_value(scaled_dt)
 
-    def start_vector_clock(self):           
+    def start_vector_clock(self) -> None:
         self.vector_clock.add_updater(self.vector_clock_time_updater)
 
-    def stop_vector_clock(self):
+    def stop_vector_clock(self) -> None:
         self.vector_clock.remove_updater(self.vector_clock_time_updater)
 
-    def get_fourier_coefs(self, path):
+    def get_fourier_coefs(self, path: "mn.VMobject") -> list[complex]:
+        """Compute Fourier coefficients for the given `path`.
+
+        Samples the path at `self.path_n_samples` points and produces complex
+        coefficients ordered according to `self.freqs`.
+        """
         dt = 1 / self.path_n_samples
         t_range = np.arange(0, 1, dt)
 
@@ -75,9 +90,14 @@ class FourierSceneAbstract(mn.ZoomedScene):
         ]
         return coefficients
 
-    def get_fourier_vectors(self, path):
+    def get_fourier_vectors(self, path: "mn.VMobject") -> "mn.VGroup":
+        """Create a `VGroup` of vectors from Fourier coefficients for `path`.
+
+        Each produced vector has attributes `.freq`, `.coef`, `.phase`, and
+        `.center_func` so that other helpers can position and animate them.
+        """
         coefficients = self.get_fourier_coefs(path)
-        
+
         vectors = mn.VGroup()
         v_is_first_vector = True
         for coef, freq in zip(coefficients,self.freqs):
@@ -97,13 +117,18 @@ class FourierSceneAbstract(mn.ZoomedScene):
             vectors.add(v)
         return vectors
 
-    def update_vectors(self, vectors):
-            for v in vectors:
-                time = self.vector_clock.get_value()
-                v.shift(v.center_func()-v.get_start())
-                v.set_angle(v.phase + time * v.freq * mn.TAU)  # NOTE Rotate() did not work here for unknown reason, probably related to how manin handles updaters
+    def update_vectors(self, vectors: "mn.VGroup") -> None:
+        """Updater to reposition and rotate vectors each frame.
+
+        Intended to be added as an updater to a `VGroup` of vectors.
+        """
+        for v in vectors:
+            time = self.vector_clock.get_value()
+            v.shift(v.center_func()-v.get_start())
+            v.set_angle(v.phase + time * v.freq * mn.TAU)  # NOTE Rotate() did not work here for unknown reason, probably related to how manin handles updaters
               
-    def get_circles(self, vectors):
+    def get_circles(self, vectors: "mn.VGroup") -> "mn.VGroup":
+        """Create circles centered on each vector start."""
         circles = mn.VGroup()
         for v in vectors:
             c = mn.Circle(radius = v.get_length(), **self.circle_config)
@@ -112,11 +137,17 @@ class FourierSceneAbstract(mn.ZoomedScene):
             circles.add(c)
         return circles
 
-    def update_circles(self, circles):
+    def update_circles(self, circles: "mn.VGroup") -> None:
+        """Updater to move each circle to its stored `center_func` location."""
         for c in circles:
             c.move_to(c.center_func())
             
-    def get_drawn_path(self, vectors):
+    def get_drawn_path(self, vectors: Iterable["mn.Vector"]) -> "mn.CurvesAsSubmobjects":
+        """Compute the path traced by summing the Fourier vectors.
+
+        `vectors` should be a `VGroup` where each element exposes `.coef` and
+        `.freq`. The result is suitable for progressive reveal via an updater.
+        """
 
         def fourier_series_func(t):
             fss = np.sum(np.array([
@@ -134,7 +165,8 @@ class FourierSceneAbstract(mn.ZoomedScene):
         broken_path.end_width = self.drawn_path_interpolation_config[1]
         return broken_path
 
-    def update_path(self, broken_path):
+    def update_path(self, broken_path: "mn.CurvesAsSubmobjects") -> None:
+        """Reveal the broken path by interpolating stroke width."""
         alpha = self.vector_clock.get_value()
         n_curves = len(broken_path)
         alpha_range = np.linspace(0, 1, n_curves)
@@ -150,7 +182,7 @@ class FourierScene(FourierSceneAbstract):
     def __init__(self):
         super().__init__()
 
-    def get_tex_symbol(self, symbol, color = None):
+    def get_tex_symbol(self, symbol: str, color: "mn.ManimColor" = None) -> "mn.Tex":
         symbol = mn.Tex(symbol, **self.fourier_symbol_config)
     
         if (color is not None):
@@ -158,10 +190,10 @@ class FourierScene(FourierSceneAbstract):
 
         return symbol
 
-    def get_path_from_symbol(self, symbol):
+    def get_path_from_symbol(self, symbol: "mn.Tex") -> "mn.VMobject":
         return symbol.family_members_with_points()[0]
 
-    def construct(self):
+    def construct(self) -> None:
         # Symbols to draw
         symbol1 = self.get_tex_symbol("m", mn.RED)
         symbol2 = self.get_tex_symbol("e", mn.BLUE)
@@ -186,7 +218,7 @@ class FourierScene(FourierSceneAbstract):
         # Camera updater
         last_vector = vectors1[-1]
 
-        def follow_end_vector(camera): 
+        def follow_end_vector(camera: "mn.Camera") -> None: 
             camera.move_to(last_vector.get_end())
 
         # Scene start

--- a/fourierseries.py
+++ b/fourierseries.py
@@ -5,13 +5,13 @@
 # Inspired by brilliant math youtuber 3Blue1Brown, creator of the Manim Python library:
 # 3lue1Brown link:              https://www.youtube.com/watch?v=r6sGWTCMz2k
 
-from manim import *
+import manim as mn
 import numpy as np
 # import timeit
 
 # config.use_opengl_renderer = True
 
-class FourierSceneAbstract(ZoomedScene):
+class FourierSceneAbstract(mn.ZoomedScene):
     def __init__(self):
         super().__init__()
         self.fourier_symbol_config = {
@@ -29,7 +29,7 @@ class FourierSceneAbstract(ZoomedScene):
         self.circle_config = {
             "stroke_width": 1,
             "stroke_opacity": 0.3,
-            "color": WHITE
+            "color": mn.WHITE
         }
         self.n_vectors = 40
         self.cycle_seconds = 5
@@ -42,8 +42,8 @@ class FourierSceneAbstract(ZoomedScene):
 
     def setup(self):
         super().setup()
-        self.vector_clock = ValueTracker()
-        self.slow_factor_tracker = ValueTracker(0)
+        self.vector_clock = mn.ValueTracker()
+        self.slow_factor_tracker = mn.ValueTracker(0)
         self.add(self.vector_clock)
 
     def vector_clock_time_updater(self, t, dt):
@@ -68,7 +68,7 @@ class FourierSceneAbstract(ZoomedScene):
 
         coefficients = [
             np.sum(np.array([
-                c_point * np.exp(-TAU * 1j * freq * t) * dt
+                c_point * np.exp(-mn.TAU * 1j * freq * t) * dt
                 for t, c_point in zip(t_range, complex_points)
                 ]))
             for freq in self.freqs
@@ -78,12 +78,12 @@ class FourierSceneAbstract(ZoomedScene):
     def get_fourier_vectors(self, path):
         coefficients = self.get_fourier_coefs(path)
         
-        vectors = VGroup()
+        vectors = mn.VGroup()
         v_is_first_vector = True
         for coef, freq in zip(coefficients,self.freqs):
-            v = Vector([np.real(coef), np.imag(coef)], **self.vector_config)
+            v = mn.Vector([np.real(coef), np.imag(coef)], **self.vector_config)
             if v_is_first_vector:
-                center_func = VectorizedPoint(ORIGIN).get_location # Function to center position at tip of last vector
+                center_func = mn.VectorizedPoint(mn.ORIGIN).get_location # Function to center position at tip of last vector
                 v_is_first_vector = False
             else:
                 center_func = last_v.get_end
@@ -101,12 +101,12 @@ class FourierSceneAbstract(ZoomedScene):
             for v in vectors:
                 time = self.vector_clock.get_value()
                 v.shift(v.center_func()-v.get_start())
-                v.set_angle(v.phase + time * v.freq * TAU)  # NOTE Rotate() did not work here for unknown reason, probably related to how manin handles updaters
+                v.set_angle(v.phase + time * v.freq * mn.TAU)  # NOTE Rotate() did not work here for unknown reason, probably related to how manin handles updaters
               
     def get_circles(self, vectors):
-        circles = VGroup()
+        circles = mn.VGroup()
         for v in vectors:
-            c = Circle(radius = v.get_length(), **self.circle_config)
+            c = mn.Circle(radius = v.get_length(), **self.circle_config)
             c.center_func = v.get_start
             c.move_to(c.center_func())
             circles.add(c)
@@ -120,15 +120,15 @@ class FourierSceneAbstract(ZoomedScene):
 
         def fourier_series_func(t):
             fss = np.sum(np.array([
-                v.coef * np.exp(TAU * 1j * v.freq * t)
+                v.coef * np.exp(mn.TAU * 1j * v.freq * t)
                 for v in vectors
             ]))
             real_fss = np.array([np.real(fss), np.imag(fss), 0])
             return real_fss
         
         t_range = np.array([0, 1, self.parametric_func_step])
-        vector_sum_path = ParametricFunction(fourier_series_func, t_range = t_range)
-        broken_path = CurvesAsSubmobjects(vector_sum_path)
+        vector_sum_path = mn.ParametricFunction(fourier_series_func, t_range = t_range)
+        broken_path = mn.CurvesAsSubmobjects(vector_sum_path)
         broken_path.stroke_width = 0
         broken_path.start_width = self.drawn_path_interpolation_config[0]
         broken_path.end_width = self.drawn_path_interpolation_config[1]
@@ -143,7 +143,7 @@ class FourierSceneAbstract(ZoomedScene):
             if b < 0:
                 width = 0
             else:
-                width = self.drawn_path_stroke_width * interpolate(broken_path.start_width, broken_path.end_width, (1 - (b % 1)))
+                width = self.drawn_path_stroke_width * mn.interpolate(broken_path.start_width, broken_path.end_width, (1 - (b % 1)))
             subpath.set_stroke(width=width)
 
 class FourierScene(FourierSceneAbstract):
@@ -151,7 +151,7 @@ class FourierScene(FourierSceneAbstract):
         super().__init__()
 
     def get_tex_symbol(self, symbol, color = None):
-        symbol = Tex(symbol, **self.fourier_symbol_config)
+        symbol = mn.Tex(symbol, **self.fourier_symbol_config)
     
         if (color is not None):
             symbol.set_color(color)
@@ -163,25 +163,25 @@ class FourierScene(FourierSceneAbstract):
 
     def construct(self):
         # Symbols to draw
-        symbol1 = self.get_tex_symbol("m", RED)
-        symbol2 = self.get_tex_symbol("e", BLUE)
-        group = VGroup(symbol1, symbol2).arrange(RIGHT)
+        symbol1 = self.get_tex_symbol("m", mn.RED)
+        symbol2 = self.get_tex_symbol("e", mn.BLUE)
+        group = mn.VGroup(symbol1, symbol2).arrange(mn.RIGHT)
 
         # Fourier series for symbol1
         vectors1 = self.get_fourier_vectors(self.get_path_from_symbol(symbol1))
         circles1 = self.get_circles(vectors1)
-        drawn_path1 = self.get_drawn_path(vectors1).set_color(RED)
+        drawn_path1 = self.get_drawn_path(vectors1).set_color(mn.RED)
 
         # Fourier series for symbol2
         vectors2 = self.get_fourier_vectors(self.get_path_from_symbol(symbol2))
         circles2 = self.get_circles(vectors2)
-        drawn_path2 = self.get_drawn_path(vectors2).set_color(BLUE)
+        drawn_path2 = self.get_drawn_path(vectors2).set_color(mn.BLUE)
 
         # Text definition
-        text = Tex("hire", fill_opacity = 1, height = 3)
-        text.next_to(group, LEFT*1.4)
+        text = mn.Tex("hire", fill_opacity = 1, height = 3)
+        text.next_to(group, mn.LEFT*1.4)
 
-        all_mobs = VGroup(group, text)
+        all_mobs = mn.VGroup(group, text)
 
         # Camera updater
         last_vector = vectors1[-1]
@@ -193,12 +193,12 @@ class FourierScene(FourierSceneAbstract):
         self.wait(1)
         self.play(
             *[
-                GrowArrow(arrow)
+                mn.GrowArrow(arrow)
                 for vector_group in [vectors1, vectors2]
                 for arrow in vector_group
             ],
             *[
-                Create(circle)
+                mn.Create(circle)
                 for circle_group in [circles1, circles2]
                 for circle in circle_group
             ],
@@ -235,7 +235,7 @@ class FourierScene(FourierSceneAbstract):
         self.camera.frame.remove_updater(follow_end_vector)
         self.play(
             self.camera.frame.animate.set_width(all_mobs.width * 1.5).move_to(all_mobs.get_center()),
-            Write(text),
+            mn.Write(text),
             run_time = 1 * self.cycle_seconds,
         )
         self.wait(0.8 * self.cycle_seconds)
@@ -252,12 +252,12 @@ class FourierScene(FourierSceneAbstract):
 
         self.play(
             *[
-                Uncreate(vmobject)
+                mn.Uncreate(vmobject)
                 for vgroup in [vectors1, vectors2, circles1, circles2]
                 for vmobject in vgroup
             ],
-            FadeOut(drawn_path1, drawn_path2),
-            FadeIn(symbol1, symbol2),
+            mn.FadeOut(drawn_path1, drawn_path2),
+            mn.FadeIn(symbol1, symbol2),
             run_time = 2.5,
         )
 

--- a/fourierseries.py
+++ b/fourierseries.py
@@ -116,7 +116,7 @@ class FourierSceneAbstract(mn.ZoomedScene):
         for c in circles:
             c.move_to(c.center_func())
             
-    def get_drawn_path(self, vectors):    # TODO Find out application of None, is for placeholder, may be how keyword argument default is set
+    def get_drawn_path(self, vectors):
 
         def fourier_series_func(t):
             fss = np.sum(np.array([


### PR DESCRIPTION
Multiple minor fixes to make script more readable.

## Commits
* refactor: Use long naming for clarity, avoid unnecessary parantheses, fix typos.
* docs: Add type annotations and some docstrings for the abstract scene class.
* cleanup: Delete todo comment, after learn that None is used to make arg optional in Python.
* refactor: use tuple instead of unnecessary array.
* refactor: Use alias import instead of wildcard, to improve readability of what comes from manim library.
* refactor: Define vector_clock_time_updater as function instead of lambda, and use reference when removing updater.
* fix: Update vscode debug config, to fix deprecation warning.